### PR TITLE
Remove JCenter as a default Maven repo

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -51,7 +51,7 @@ Optional = true
 ConfigKey = MavenRepo
 Repeatable = true
 DefaultValue = https://repo1.maven.org/maven2
-DefaultValue = https://jcenter.bintray.com
+DefaultValue = https://repo.maven.apache.org/maven2
 
 [Plugin "java"]
 Toolchain = //third_party/java:toolchain

--- a/README.md
+++ b/README.md
@@ -187,12 +187,13 @@ DefaultTestPackage = please.build.
 
 ## MavenRepo
 The maven repositories to load jars from. This value can be repeated and defaults to `https://repo1.maven.org/maven2` 
-and `https://jcenter.bintray.com`. 
+and `https://repo.maven.apache.org/maven2`, the canonical Maven Central repository URLs. 
 
-To add a custom repo, you may do so by setting the following:  
+To add a custom repo, you may do so by setting the following:
+
 ```
 [Plugin "java"]
-MavenRepo = https://jcenter.bintray.com
 MavenRepo = https://repo1.maven.org/maven2
+MavenRepo = https://repo.maven.apache.org/maven2
 MavenRepo = https://maven.repo.org
 ```


### PR DESCRIPTION
JFrog announced the sunsetting of JCenter, which Please uses as one of its default Maven repos, in February 2021 [1]. Although they later U-turned and committed to indefinitely maintaining a frozen mirror in April 2021, it seems that JCenter is indeed dead now (e.g. [2]).

Sonatype [3] says that the canonical URLs for Maven Central are now https://repo1.maven.org/maven2 and https://repo.maven.apache.org/maven2 (both are hosted by Sonatype's CDN), so replace the JCenter URL with the
Apache URL in `MavenRepo`.

[1] https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/
[2] https://jcenter.bintray.com/org/apache/commons/commons-io/maven-metadata.xml
[3] https://central.sonatype.org/consume/