### PR TITLE
java_toolchain: expose JNI headers to C/C++ targets

### DIFF
--- a/build_defs/java.build_defs
+++ b/build_defs/java.build_defs
@@ -539,16 +539,15 @@ def _java_toolchain(name : str, jdk_url : str|dict='', jdk:str='', visibility:li
             hashes = hashes,
         )
 
-    if jdk:
-        if CONFIG.OS == "linux" or CONFIG.OS == "darwin" or CONFIG.OS == "freebsd" or CONFIG.OS == "openbsd":
-            java_platform = CONFIG.OS
-        elif CONFIG.OS == "windows":
-            java_platform = "win32"
+    if CONFIG.OS == "linux" or CONFIG.OS == "darwin" or CONFIG.OS == "freebsd" or CONFIG.OS == "openbsd" or CONFIG.OS == "solaris":
+        java_platform = CONFIG.OS
+    elif CONFIG.OS == "windows":
+        java_platform = "win32"
 
-        include_root = join_path(subrepo_name(), package_name(), name, "include")
-        labels = ["cc:inc:" + include_root]
-        if java_platform:
-            labels += ["cc:inc:" + join_path(include_root, java_platform)]
+    include_root = join_path(subrepo_name(), package_name(), name, "include")
+    labels = ["cc:inc:" + include_root]
+    if java_platform:
+        labels += ["cc:inc:" + join_path(include_root, java_platform)]
 
     return build_rule(
         name = name,
@@ -566,7 +565,7 @@ def _java_toolchain(name : str, jdk_url : str|dict='', jdk:str='', visibility:li
             "java": f"{name}/bin/java",
             "javac": f"{name}/bin/javac",
         },
-        labels = labels or [],
+        labels = labels,
         visibility = visibility,
     )
 

--- a/build_defs/java.build_defs
+++ b/build_defs/java.build_defs
@@ -539,6 +539,17 @@ def _java_toolchain(name : str, jdk_url : str|dict='', jdk:str='', visibility:li
             hashes = hashes,
         )
 
+    if jdk:
+        if CONFIG.OS == "linux" or CONFIG.OS == "darwin" or CONFIG.OS == "freebsd" or CONFIG.OS == "openbsd":
+            java_platform = CONFIG.OS
+        elif CONFIG.OS == "windows":
+            java_platform = "win32"
+
+        include_root = join_path(subrepo_name(), package_name(), name, "include")
+        labels = ["cc:inc:" + include_root]
+        if java_platform:
+            labels += ["cc:inc:" + join_path(include_root, java_platform)]
+
     return build_rule(
         name = name,
         srcs = [jdk],
@@ -555,6 +566,7 @@ def _java_toolchain(name : str, jdk_url : str|dict='', jdk:str='', visibility:li
             "java": f"{name}/bin/java",
             "javac": f"{name}/bin/javac",
         },
+        labels = labels or [],
         visibility = visibility,
     )
 


### PR DESCRIPTION
If the toolchain is a JDK, this allows the `c_shared_object` and `cc_shared_object` rules to find the necessary JDK headers when compiling JNI sources simply by adding the toolchain target to `hdrs`.