### PR TITLE
`java_binary`: only mark as binary when target is self-executable

### DIFF
--- a/build_defs/java.build_defs
+++ b/build_defs/java.build_defs
@@ -273,7 +273,7 @@ def java_binary(name:str, main_class:str=None, out:str=None, srcs:list=None, dep
         cmd=cmd,
         needs_transitive_deps=True,
         output_is_complete=True,
-        binary=True,
+        binary=self_executable,
         building_description="Creating jar...",
         requires=['java'],
         visibility=visibility,


### PR DESCRIPTION
It only makes sense for a `java_binary` target to be marked as executable when the output file is prefixed with a shebang, which is controlled by the value of the `self_executable` parameter.