### PR TITLE
Make `JavacTool` default to `javac`

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -17,7 +17,7 @@ Name = java
 
 [PluginConfig "javac_tool"]
 ConfigKey = JavacTool
-DefaultValue =
+DefaultValue = javac
 Inherit = True
 Help = Path to the Javac tool if not using java_toolchain
 


### PR DESCRIPTION
If `java_toolchain` isn't in use, and a `java_library` target is defined but `JavacTool` isn't, Please outputs a nondescript "Empty source path" error message when building the target. This is caused by `JavacTool` having no default value, so `None` is passed as the value of the javac `tool` to the build target generated by `javac_toolchain`.

Define `javac` as the default value of `JavacTool`. This requires a JDK to be installed system-wide in order to work, but other Please plugins make similar assumptions about the availability of their own dependencies, so this is at least consistent.

Fixes #25.