### PR TITLE
Define `JlinkTool` configuration option

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -33,6 +33,12 @@ Optional = True
 Inherit = True
 Help = Any additional flags to pass to javac for tests
 
+[PluginConfig "jlink_tool"]
+ConfigKey = JlinkTool
+DefaultValue = jlink
+Inherit = True
+Help = Path to the jlink tool
+
 [PluginConfig "junit_runner"]
 ConfigKey = JunitRunner
 DefaultValue = ///java//tools:junit_runner

--- a/build_defs/java.build_defs
+++ b/build_defs/java.build_defs
@@ -210,7 +210,7 @@ def java_runtime_image(name:str, main_module:str, main_class:str, modules:list, 
         building_description="Creating runtime image...",
         requires=['java'],
         visibility=visibility,
-        tools=[CONFIG.JLINK_TOOL],
+        tools=[CONFIG.JAVA.JLINK_TOOL],
     )
 
 def java_binary(name:str, main_class:str=None, out:str=None, srcs:list=None, deps:list=[],


### PR DESCRIPTION
This is required by the `java_runtime_image` rule, but currently isn't defined, making the rule unusable. Define it, and make sure it is used consistently.

Fixes #27.