### PR TITLE
Allow all necessary tools to be sourced from Java toolchain

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -46,7 +46,7 @@ Help = Any additional flags to pass to javac for tests
 ConfigKey = JlinkTool
 DefaultValue = jlink
 Inherit = True
-Help = Path to the jlink tool
+Help = Path to the jlink tool if not using java_toolchain
 
 [PluginConfig "junit_runner"]
 ConfigKey = JunitRunner

--- a/.plzconfig
+++ b/.plzconfig
@@ -12,6 +12,18 @@ PleaseVersion = 16.27.1
 [PluginDefinition]
 Name = java
 
+[PluginConfig "java_tool"]
+ConfigKey = JavaTool
+DefaultValue = java
+Inherit = True
+Help = Path to the Java tool if not using java_toolchain
+
+[PluginConfig "run_self_executables_with_java_tool"]
+ConfigKey = RunSelfExecutablesWithJavaTool
+DefaultValue = False
+Inherit = True
+Help = Run self-executable JAR files outputted by this plugin's rules with the Java tool (whether standalone or from a java_toolchain); otherwise, they will be run using the "java" binary in the system path. If this is enabled, JAR files may not be self-executable if they are moved, although they will still be runnable with "java -jar".
+
 [PluginConfig "javac_tool"]
 ConfigKey = JavacTool
 DefaultValue = javac

--- a/.plzconfig
+++ b/.plzconfig
@@ -1,5 +1,5 @@
 [Please]
-version = 17.0.0-beta.6
+version = 17.4.0-beta.10
 
 [Plugin "java"]
 Toolchain = //third_party/java:toolchain

--- a/build_defs/java.build_defs
+++ b/build_defs/java.build_defs
@@ -558,16 +558,24 @@ def _java_toolchain(name : str, jdk_url : str|dict='', jdk:str='', visibility:li
     # The jlink binary was added to the JDK in Java 9, as part of the module system - it can only be
     # added as an entry point if we detect that the toolchain will provide Java >= 9.
     def _add_jlink_entry_point(name, output):
-        # The output of "java -fullversion" is standardised in JEP 223, and matches the format
-        # expected below going back at least as far as Java 8.
+        # The output of "java -fullversion" matches the format expected below going back at least as
+        # far as Java 8.
         if len(output) == 0 or not output[0].startswith("openjdk full version "):
             fail("bin/java in the Java toolchain does not appear to be the JRE binary")
         version = output[0].removeprefix('openjdk full version "').removesuffix('"')
-        major, minor, _ = version.split(".")
-        # Java 9 and below (i.e. versions that don't fully implement JEP 223) identify themselves as
-        # version "1.w.x.y.z" rather than "w.x.y.z":
-        if major == "1":
-            major = minor
+        # "java -fullversion" outputs the value of the java.runtime.version JVM system property,
+        # whose format has changed through the ages:
+        if version.startswith("1."):
+            # Java <= 8: JDK version numbers always have an initial "1" component, the (de facto)
+            # major version number is second, and the third is always "0". Everything that follows
+            # this is irrelevant here.
+            _, major, _ = version.split(".")
+        else:
+            # Java >= 9: java.runtime.version is the value of $VSTR, defined in JEP 223. We just
+            # want the value of $MAJOR, the first component of $VNUM.
+            vnum_pre, _, _ = version.partition("+")
+            vnum, _, _ = vnum_pre.partition("-")
+            major, _, _ = vnum.partition(".")
         if int(major) >= 9:
             add_entry_point(name, "jlink", f"{name}/bin/jlink")
 

--- a/build_defs/java.build_defs
+++ b/build_defs/java.build_defs
@@ -212,7 +212,7 @@ def java_runtime_image(name:str, main_module:str, main_class:str, modules:list, 
     out = out or name
     depflags = r'`find "$TMP_DIR" -name "*.jar" | tr \\\\n :`'
     modules = ','.join(modules)
-    cmd = f"$TOOLS_JLINK --module-path {depflags}:{home}/jmods --add-modules {modules} --launcher {name}={main_module}/{main_class} --output {out} {jlink_args}",
+    cmd = f"$TOOLS_JLINK --module-path {depflags}:{home}/jmods --add-modules {modules} --launcher {name}={main_module}/{main_class} --output {out} {jlink_args}"
 
     return build_rule(
         name=name,

--- a/build_defs/java.build_defs
+++ b/build_defs/java.build_defs
@@ -192,6 +192,8 @@ def java_runtime_image(name:str, main_module:str, main_class:str, modules:list, 
                        not defined, this rule falls back to using the jlink tool defined in the plugin configuration.
     """
     if toolchain:
+        if not get_entry_points(toolchain).get("jlink"):
+            fail("%s: this Java toolchain does not provide jlink" % canonicalise(toolchain))
         home = "$TOOLS_TOOLCHAIN"
         tools = {
             "jlink": f"{toolchain}|jlink",
@@ -553,6 +555,22 @@ def _java_toolchain(name : str, jdk_url : str|dict='', jdk:str='', visibility:li
     if java_platform:
         labels += ["cc:inc:" + join_path(include_root, java_platform)]
 
+    # The jlink binary was added to the JDK in Java 9, as part of the module system - it can only be
+    # added as an entry point if we detect that the toolchain will provide Java >= 9.
+    def _add_jlink_entry_point(name, output):
+        # The output of "java -fullversion" is standardised in JEP 223, and matches the format
+        # expected below going back at least as far as Java 8.
+        if len(output) == 0 or not output[0].startswith("openjdk full version "):
+            fail("bin/java in the Java toolchain does not appear to be the JRE binary")
+        version = output[0].removeprefix('openjdk full version "').removesuffix('"')
+        major, minor, _ = version.split(".")
+        # Java 9 and below (i.e. versions that don't fully implement JEP 223) identify themselves as
+        # version "1.w.x.y.z" rather than "w.x.y.z":
+        if major == "1":
+            major = minor
+        if int(major) >= 9:
+            add_entry_point(name, "jlink", f"{name}/bin/jlink")
+
     return build_rule(
         name = name,
         srcs = [jdk],
@@ -562,15 +580,16 @@ def _java_toolchain(name : str, jdk_url : str|dict='', jdk:str='', visibility:li
             '"$TOOL" x $SRCS -o extract_dir',
             f'mv $(dirname $(dirname $(find extract_dir/ -name javac))) {name}',
             f"chmod +x {name}/bin/*",
+            f"{name}/bin/java -fullversion 2>&1",
         ]),
         binary = True,
         building_description = 'Extracting...',
         entry_points = {
             "java": f"{name}/bin/java",
             "javac": f"{name}/bin/javac",
-            "jlink": f"{name}/bin/jlink",
         },
         labels = labels,
+        post_build = _add_jlink_entry_point,
         visibility = visibility,
     )
 

--- a/build_defs/java.build_defs
+++ b/build_defs/java.build_defs
@@ -174,7 +174,8 @@ def java_module(name:str, srcs:list=None, src_dir:str=None, resources:list=None,
 
 def java_runtime_image(name:str, main_module:str, main_class:str, modules:list, out:str=None,
                        deps:list=[], data:list=None, visibility:list=None,
-                       jlink_args:str='--strip-debug --compress=2'):
+                       jlink_args:str='--strip-debug --compress=2',
+                       toolchain:str=CONFIG.JAVA.TOOLCHAIN):
     """Assembles a set of modules into an executable java runtime image.
 
     Args:
@@ -187,17 +188,31 @@ def java_runtime_image(name:str, main_module:str, main_class:str, modules:list, 
       data (list): Deprecated, has no effect.
       visibility (list): Visibility declaration of this rule.
       jlink_args (str): Arguments to pass to the JVM in the run script.
+      toolchain (str): The build target for a java_toolchain that will be used to build this image. If a toolchain is
+                       not defined, this rule falls back to using the jlink tool defined in the plugin configuration.
     """
-    if not CONFIG.JAVA.HOME:
-        fail('Java home needs to be set to link java runtime images against jmods.')
-    if not CONFIG.JAVA.JLINK_TOOL:
-        fail('A jlink tool is required to build java runtime images.')
+    if toolchain:
+        home = "$TOOLS_TOOLCHAIN"
+        tools = {
+            "jlink": f"{toolchain}|jlink",
+            "toolchain": toolchain,
+        }
+    else:
+        if not CONFIG.JAVA.HOME:
+            fail("JAVA_HOME needs to be set to link Java runtime images against jmods.")
+        if not CONFIG.JAVA.JLINK_TOOL:
+            fail("A jlink tool is required to build Java runtime images.")
+        home = CONFIG.JAVA.HOME
+        tools = {
+            "jlink": CONFIG.JAVA.JLINK_TOOL,
+        }
+
     if not modules:
-        fail('You cannot assemble a java runtime image without specifying any modules.')
+        fail("You cannot assemble a Java runtime image without specifying any modules.")
     out = out or name
     depflags = r'`find "$TMP_DIR" -name "*.jar" | tr \\\\n :`'
     modules = ','.join(modules)
-    cmd = f"$TOOL --module-path {depflags}:{CONFIG.JAVA.HOME}/jmods --add-modules {modules} --launcher {name}={main_module}/{main_class} --output {out} {jlink_args}"
+    cmd = f"$TOOLS_JLINK --module-path {depflags}:{home}/jmods --add-modules {modules} --launcher {name}={main_module}/{main_class} --output {out} {jlink_args}",
 
     return build_rule(
         name=name,
@@ -210,11 +225,11 @@ def java_runtime_image(name:str, main_module:str, main_class:str, modules:list, 
         building_description="Creating runtime image...",
         requires=['java'],
         visibility=visibility,
-        tools=[CONFIG.JAVA.JLINK_TOOL],
+        tools=tools,
     )
 
 def java_binary(name:str, main_class:str=None, out:str=None, srcs:list=None, deps:list=[],
-                data:list=None, visibility:list=None, jvm_args:str=None, labels:list=[],
+                data:list=[], visibility:list=None, jvm_args:str=None, labels:list=[],
                 self_executable:bool=True, manifest:str=None, toolchain:str=CONFIG.JAVA.TOOLCHAIN):
     """Compiles a .jar from a set of Java libraries.
 
@@ -231,7 +246,7 @@ def java_binary(name:str, main_class:str=None, out:str=None, srcs:list=None, dep
       self_executable (bool): True to make the jar self executable.
       manifest (str): Manifest file to put into the jar. Can't be passed at the same time as
                       main_class.
-      toolchain (str): A label identifying a java_toolchain rule which will be used to build this java binary.
+      toolchain (str): A label identifying a java_toolchain rule which will be used to build this Java binary.
     """
     if main_class and manifest:
         fail("Can't pass both main_class and manifest to java_binary")
@@ -245,7 +260,15 @@ def java_binary(name:str, main_class:str=None, out:str=None, srcs:list=None, dep
         deps += [lib_rule]
     # TODO(jpoole): Remove self exec flag and do this always once JavaBinaryExecutableByDefault has been merged
     if self_executable:
-        preamble = '#!/bin/sh\nexec java %s -jar $0 ${@}' % (jvm_args or '')
+        if CONFIG.JAVA.RUN_SELF_EXECUTABLES_WITH_JAVA_TOOL:
+            if toolchain:
+                java = f"$(out_location {toolchain}|java)"
+                data += [f"{toolchain}|java"]
+            else:
+                java = CONFIG.JAVA.JAVA_TOOL
+        else:
+            java = "java"
+        preamble = "#!/bin/sh\nexec %s %s -jar $0 ${@}" % (java, (jvm_args or ""))
         cmd, tools = _jarcat_cmd(main_class, preamble, manifest=manifest)
     else:
         # This is essentially a hack to get past some Java things (notably Jersey) failing
@@ -314,7 +337,7 @@ def java_test(name:str, srcs:list, resources:list=None, resources_root:str=None,
     if toolchain:
         java = f'{toolchain}|java'
     else:
-        java = 'java'
+        java = CONFIG.JAVA.JAVA_TOOL
 
     cmd = 'ln -s "$(if [ -f "$TOOLS_JUNIT" ]; then echo "$TOOLS_JUNIT"; else echo "$(which "$TOOLS_JUNIT")"; fi)" . && ' + cmd
     test_cmd = f'$TOOLS_JAVA -Dbuild.please.testpackage={test_package} {jvm_args} -jar $(location :{name}) {flags}'
@@ -545,6 +568,7 @@ def _java_toolchain(name : str, jdk_url : str|dict='', jdk:str='', visibility:li
         entry_points = {
             "java": f"{name}/bin/java",
             "javac": f"{name}/bin/javac",
+            "jlink": f"{name}/bin/jlink",
         },
         labels = labels,
         visibility = visibility,


### PR DESCRIPTION
Certain Java build rules provided by this plugin accept and make use of a Java toolchain outputted by `java_toolchain` in order to compile Java code (via `javac`) and run test JARs (via `java`). Extend the rules so that all JDK tools that they depend upon can be provided by a Java toolchain; in practice the only additional tool that the toolchain needs to provide is jlink (for `java_runtime_image`), although jlink was added in Java 9 which means that `java_runtime_image` is only usable with a `java_toolchain` that provides JDK 9 or newer. There's a run-time check for this in the build rule.

This adds two new plugin configuration options, `JavaTool` and `RunSelfExecutablesWithJavaTool`. The former is used whenever the `java` binary is required and no toolchain is defined. The latter controls whether this tool is invoked as part of the preamble in self-executable JARs outputted by `java_binary`; if this is enabled, none of the build commands executed by (or outputs from) the rules in this plugin require a JRE or JDK to be present in the system path, although self-executable JARs will need to be run with `java -jar` if they are moved outside of the Please repo. This option causes breaking changes when enabled and is therefore disabled by default.