### PR TITLE
Require Please v17.4.0 at a minimum

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -1,5 +1,5 @@
 [Please]
-version = 17.4.0-beta.10
+version = >=17.4.0
 
 [Plugin "java"]
 Toolchain = //third_party/java:toolchain


### PR DESCRIPTION
This guarantees that the `add_entry_point` built-in function is available to `java_toolchain`.