### PR TITLE
`java_runtime_image`: interpolate the correct strings

### DIFF
--- a/build_defs/java.build_defs
+++ b/build_defs/java.build_defs
@@ -241,8 +241,8 @@ def java_runtime_image(name:str, out:str=None, modules:list, launcher_module:str
         deps=deps,
         outs=[out],
         cmd={
-            "dbg": f"$TOOLS_JLINK " + " ".join(default_jlink_args) + " {jlink_args}",
-            "opt": f"$TOOLS_JLINK " + " ".join(default_jlink_args) + " --strip-debug {jlink_args}",
+            "dbg": "$TOOLS_JLINK " + " ".join(default_jlink_args) + f" {jlink_args}",
+            "opt": "$TOOLS_JLINK " + " ".join(default_jlink_args) + f" --strip-debug {jlink_args}",
         },
         needs_transitive_deps=True,
         output_is_complete=True,


### PR DESCRIPTION
These strings were refactored in #37 but the wrong part of the string is now being interpolated with the f-string notation.