### PR TITLE
`java_runtime_image`: remove check for jlink support in `java_toolchain`

### DIFF
--- a/build_defs/java.build_defs
+++ b/build_defs/java.build_defs
@@ -199,8 +199,6 @@ def java_runtime_image(name:str, out:str=None, modules:list, launcher_module:str
       deps (list): Dependencies of this rule.
     """
     if toolchain:
-        if not get_entry_points(toolchain).get("jlink"):
-            fail("%s: this Java toolchain does not provide jlink" % canonicalise(toolchain))
         home = "$TOOLS_TOOLCHAIN"
         tools = {
             "jlink": f"{toolchain}|jlink",


### PR DESCRIPTION
This check is too strict - it will always fail, because the `jlink` entry point won't have been added to the toolchain target by the post-build function in `java_toolchain` by the time the `java_runtime_image` target is parsed. Remove it, and rely on the "no such entry point" error Please will later produce when trying to build the target returned by `java_runtime_image` using a `java_toolchain` that doesn't contain jlink.