### PR TITLE
Guard against empty optional plugin config fields

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -1,5 +1,5 @@
 [Please]
-version = >=17.4.0
+version = >=17.10.1
 
 [Plugin "java"]
 Toolchain = //third_party/java:toolchain

--- a/build_defs/java.build_defs
+++ b/build_defs/java.build_defs
@@ -45,6 +45,8 @@ def java_library(name:str, srcs:list=None, src_dir:str=None, resources:list=[], 
                 javac_flags = CONFIG.JAVA.JAVAC_TEST_FLAGS
             elif CONFIG.JAVA.JAVAC_FLAGS is not None:
                 javac_flags = CONFIG.JAVA.JAVAC_FLAGS
+            else:
+                javac_flags = ""
 
         javac_flags = '-g -encoding utf8 ' + javac_flags
 

--- a/build_defs/java.build_defs
+++ b/build_defs/java.build_defs
@@ -41,7 +41,10 @@ def java_library(name:str, srcs:list=None, src_dir:str=None, resources:list=[], 
             # it doesn't mean anything to us so we must filter it out.
             javac_flags = ' '.join([flag for flag in javac_flags if flag != '-extra_checks:off'])
         else:
-            javac_flags = CONFIG.JAVA.JAVAC_TEST_FLAGS if test_only else CONFIG.JAVA.JAVAC_FLAGS
+            if test_only and CONFIG.JAVA.JAVAC_TEST_FLAGS is not None:
+                javac_flags = CONFIG.JAVA.JAVAC_TEST_FLAGS
+            elif CONFIG.JAVA.JAVAC_FLAGS is not None:
+                javac_flags = CONFIG.JAVA.JAVAC_FLAGS
 
         javac_flags = '-g -encoding utf8 ' + javac_flags
 
@@ -205,9 +208,9 @@ def java_runtime_image(name:str, out:str=None, modules:list, launcher_module:str
             "toolchain": toolchain,
         }
     else:
-        if not CONFIG.JAVA.HOME:
+        if CONFIG.JAVA.HOME is None:
             fail("JAVA_HOME needs to be set to link Java runtime images against jmods.")
-        if not CONFIG.JAVA.JLINK_TOOL:
+        if CONFIG.JAVA.JLINK_TOOL is None:
             fail("A jlink tool is required to build Java runtime images.")
         home = CONFIG.JAVA.HOME
         tools = {
@@ -362,8 +365,10 @@ def java_test(name:str, srcs:list, resources:list=None, resources_root:str=None,
     else:
         java = CONFIG.JAVA.JAVA_TOOL
 
+    test_package_arg = "-Dbuild.please.testpackage={test_package}" if test_package is not None else ""
+
     cmd = 'ln -s "$(if [ -f "$TOOLS_JUNIT" ]; then echo "$TOOLS_JUNIT"; else echo "$(which "$TOOLS_JUNIT")"; fi)" . && ' + cmd
-    test_cmd = f'$TOOLS_JAVA -Dbuild.please.testpackage={test_package} {jvm_args} -jar $(location :{name}) {flags}'
+    test_cmd = f"$TOOLS_JAVA {test_package_arg} {jvm_args} -jar $(location :{name}) {flags}"
 
     deps = [lib_rule]
     return build_rule(


### PR DESCRIPTION
In Please >= v17.10.0, the `javac_flags`, `javac_test_flags` and `default_test_package` plugin config fields could all have `None` values from the perspective of the build defs.